### PR TITLE
Work around github actions checkout not creating a file for the remote HEAD

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ runs:
   using: "composite"
   steps:
     - name: Fix default branch discovery for devbox
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
       run: |
         DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq .default_branch)"

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
       run: |
-        DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq .default_branch)"
-        echo "ref: refs/remote/origin/${DEFAULT_BRANCH}" > .git/refs/remotes/origin/HEAD
+        DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq -r .default_branch)"
+        echo "ref: refs/remotes/origin/${DEFAULT_BRANCH}" > .git/refs/remotes/origin/HEAD
 
     - name: Run templater
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Fix default branch discovery for devbox
+      shell: bash
+      run: |
+        DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq .default_branch)"
+        echo "ref: refs/remote/origin/${DEFAULT_BRANCH}" > .git/refs/remotes/origin/HEAD
+
     - name: Run templater
       shell: bash
       run: |

--- a/action.yml.erb
+++ b/action.yml.erb
@@ -28,6 +28,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Fix default branch discovery for devbox
+      shell: bash
+      run: |
+        @import script-import-helper (script_name: "fix-branch-discovery.bash")
     - name: Run templater
       shell: bash
       run: |

--- a/action.yml.erb
+++ b/action.yml.erb
@@ -29,6 +29,8 @@ runs:
   using: "composite"
   steps:
     - name: Fix default branch discovery for devbox
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
       run: |
         @import script-import-helper (script_name: "fix-branch-discovery.bash")

--- a/fix-branch-discovery.bash
+++ b/fix-branch-discovery.bash
@@ -1,2 +1,2 @@
-DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq .default_branch)"
-echo "ref: refs/remote/origin/${DEFAULT_BRANCH}" > .git/refs/remotes/origin/HEAD
+DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq -r .default_branch)"
+echo "ref: refs/remotes/origin/${DEFAULT_BRANCH}" > .git/refs/remotes/origin/HEAD

--- a/fix-branch-discovery.bash
+++ b/fix-branch-discovery.bash
@@ -1,0 +1,2 @@
+DEFAULT_BRANCH="$(gh api "/repos/${GITHUB_REPOSITORY}" | jq .default_branch)"
+echo "ref: refs/remote/origin/${DEFAULT_BRANCH}" > .git/refs/remotes/origin/HEAD


### PR DESCRIPTION
github `actions/checkout@v2` does not `git clone` a repository, and as a result the remote HEAD ref does not exist.

This creates it pointing at the default branch discovered from the github API to allow devbox to discover the ref.